### PR TITLE
Update gen_local_rsa_key.pl for strongSwan 5.2.x

### DIFF
--- a/scripts/gen_local_rsa_key.pl
+++ b/scripts/gen_local_rsa_key.pl
@@ -100,13 +100,7 @@ if (-e $temp_key_file) {
     }
 }
 
-$cmd = "/usr/lib/ipsec/newhostkey --output $local_key_file --bits $bits";
-#
-# The default random number generator is /dev/random, but it will block 
-# if there isn't enough system activity to provide enough "good" random
-# bits.  Try /dev/urandom if it's taking too long.
-#
-$cmd .= " --random $device";
+$cmd = "/usr/sbin/ipsec pki --gen --outform pem --size $bits > $local_key_file";
 
 # when presenting to users, show shortened /config path
 my $shortened_cfg_path_file = get_short_config_path($local_key_file);
@@ -117,6 +111,7 @@ $rc = system($cmd);
 if ($rc != 0) {
     die "Can not generate RSA key: $!\n";
 }
+chmod 0600, $local_key_file;
 
 my $file_pubkey = rsa_get_local_pubkey($local_key_file);
 if ($file_pubkey ne 0) {


### PR DESCRIPTION
There is no /usr/lib/ipsec/newhostkey script with strongSwan 5.2.x
so gen_local_rsa_key.pl needs to use the 'ipsec pki --gen' interface
instead. The new key generator does not allow the user to specify
the source of random numbers, so we ignore the '--random' parameter.
